### PR TITLE
Add /user/allIDs, /user/mostActiveIDs

### DIFF
--- a/als-common/src/main/java/com/cloudera/oryx/als/common/OryxRecommender.java
+++ b/als-common/src/main/java/com/cloudera/oryx/als/common/OryxRecommender.java
@@ -119,7 +119,7 @@ public interface OryxRecommender {
    * @param howMany desired number of most similar items to find
    * @param rescorer {@link PairRescorer} which can adjust item-item similarity estimates used to determine
    *  most similar items. The longs that will be passed to the {@link PairRescorer} are
-   *  the candidate item that might be returned in the result as its first element, and the 
+   *  the candidate item that might be returned in the result as its first element, and the
    *  {@code itemID} argument here as its second element.
    * @return items most similar to the given item, ordered from most similar to least
    * @throws NoSuchItemException if the item is not known
@@ -142,7 +142,7 @@ public interface OryxRecommender {
    * @param howMany desired number of most similar items to find
    * @param rescorer {@link PairRescorer} which can adjust item-item similarity estimates used to determine
    *  most similar items. The longs that will be passed to the {@link PairRescorer} are
-   *  the candidate item that might be returned in the result as its first element, and one of the 
+   *  the candidate item that might be returned in the result as its first element, and one of the
    *  {@code itemID} arguments here as its second element.
    * @return items most similar to the given items, ordered from most similar to least
    * @throws NoSuchItemException if <em>none</em> of {@code itemIDs}
@@ -208,7 +208,7 @@ public interface OryxRecommender {
    * Computes recommendations for a user that is not known to the model yet; instead, the user's
    * associated items are supplied to the method and it proceeds as if a user with these associated
    * items were in the model.
-   * 
+   *
    * @param itemIDs item IDs that the anonymous user has interacted with
    * @param howMany how many recommendations to return
    * @see #recommend(String, int)
@@ -325,19 +325,19 @@ public interface OryxRecommender {
    * vector formed by projecting the given items together into the latent feature space, and then
    * recommending to that user vector (high dot product items), which is slightly different
    * from the other method.</p>
-   * 
+   *
    * @param toItemID item for which the anonymous user's strength of interaction is to be estimated
    * @param itemIDs item IDs that the anonymous user has interacted with
    * @see #recommendToAnonymous(String[], float[], int)
    * @see #mostSimilarItems(String, int)
    */
   float estimateForAnonymous(String toItemID, String[] itemIDs) throws NotReadyException, NoSuchItemException;
-  
+
   /**
    * A version of {@link #estimatePreference(String, String)} that, like
    * {@link #recommendToAnonymous(String[], float[], int)}, operates on "anonymous" users --
    * defined not by a previously known set of data, but data given in the request.
-   * 
+   *
    * @param toItemID item for which the anonymous user's strength of interaction is to be estimated
    * @param itemIDs item IDs that the anonymous user has interacted with
    * @param values values corresponding to {@code itemIDs}
@@ -345,7 +345,7 @@ public interface OryxRecommender {
    */
   float estimateForAnonymous(String toItemID, String[] itemIDs, float[] values)
       throws NotReadyException, NoSuchItemException;
-  
+
   /**
    * Like {@link #ingest(File)}, but reads from a {@link Reader}.
    *
@@ -378,6 +378,12 @@ public interface OryxRecommender {
   Collection<String> getAllItemIDs() throws NotReadyException;
 
   /**
+   * @return all user IDs currently present in the model
+   * @throws NotReadyException
+   */
+  Collection<String> getAllUserIDs() throws NotReadyException;
+
+  /**
    * @param userID user to get known items for
    * @return a {@link Collection} of item IDs that the model records that the user has interacted
    *  with. This is the same set of items that are excluded from
@@ -388,6 +394,14 @@ public interface OryxRecommender {
    */
   Collection<String> getKnownItemsForUser(String userID) throws NotReadyException;
 
+  /**
+   * @param howMany how many users to return
+   * @return {@link List} of user {@link IDValue}s, ordered from the most number of interaction with
+   * distinct items to least.
+   * @throws NotReadyException if the implementation has no usable model yet
+   */
+  List<IDValue> getMostActiveUsers(int howMany) throws NotReadyException;
+
     /**
      * @return true if and only if the instance is ready to make recommendations; may be false for example
      *  while the recommender is still building an initial model
@@ -396,7 +410,7 @@ public interface OryxRecommender {
 
   /**
    * Blocks indefinitely until {@link #isReady()} returns {@code true}.
-   * 
+   *
    * @throws InterruptedException if the thread is interrupted while waiting
    */
   void await() throws InterruptedException;

--- a/als-serving/src/main/java/com/cloudera/oryx/als/serving/web/ALSServingInitListener.java
+++ b/als-serving/src/main/java/com/cloudera/oryx/als/serving/web/ALSServingInitListener.java
@@ -102,6 +102,8 @@ public final class ALSServingInitListener extends AbstractOryxServingInitListene
     addServlet(context, new MostPopularItemsServlet(), "/mostPopularItems/*");
     addServlet(context, new PopularRepresentativeItemsServlet(), "/popularRepresentativeItems/*");
     addServlet(context, new AllItemIDsServlet(), "/item/allIDs");
+    addServlet(context, new AllUserIDsServlet(), "/user/allIDs");
+    addServlet(context, new MostActiveUsersServlet(), "/user/mostActiveIDs");
     addServlet(context, new KnownItemsServlet(), "/knownItems/*");
     addServlet(context, new MostSurprisingServlet(), "/mostSurprising/*");
     if (!ConfigUtils.getDefaultConfig().getBoolean("serving-layer.api.read-only")) {

--- a/als-serving/src/main/java/com/cloudera/oryx/als/serving/web/ALSServingInitListener.java
+++ b/als-serving/src/main/java/com/cloudera/oryx/als/serving/web/ALSServingInitListener.java
@@ -100,10 +100,10 @@ public final class ALSServingInitListener extends AbstractOryxServingInitListene
     addServlet(context, new BecauseServlet(), "/because/*");
     addServlet(context, new ReadyServlet(), "/ready/*");
     addServlet(context, new MostPopularItemsServlet(), "/mostPopularItems/*");
+    addServlet(context, new MostActiveUsersServlet(), "/mostActiveUsers");
     addServlet(context, new PopularRepresentativeItemsServlet(), "/popularRepresentativeItems/*");
     addServlet(context, new AllItemIDsServlet(), "/item/allIDs");
     addServlet(context, new AllUserIDsServlet(), "/user/allIDs");
-    addServlet(context, new MostActiveUsersServlet(), "/user/mostActiveIDs");
     addServlet(context, new KnownItemsServlet(), "/knownItems/*");
     addServlet(context, new MostSurprisingServlet(), "/mostSurprising/*");
     if (!ConfigUtils.getDefaultConfig().getBoolean("serving-layer.api.read-only")) {

--- a/als-serving/src/main/java/com/cloudera/oryx/als/serving/web/AllUserIDsServlet.java
+++ b/als-serving/src/main/java/com/cloudera/oryx/als/serving/web/AllUserIDsServlet.java
@@ -1,0 +1,28 @@
+package com.cloudera.oryx.als.serving.web;
+
+import com.cloudera.oryx.als.common.NotReadyException;
+import com.cloudera.oryx.als.common.OryxRecommender;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * <p>Responds to a GET request to {@code /user/allIDs}
+ * and in turn calls {@link com.cloudera.oryx.als.common.OryxRecommender#getAllUserIDs()}.</p>
+ *
+ * <p>CSV output is one user ID per line. JSON output is an array of user IDs.</p>
+ *
+ */
+public final class AllUserIDsServlet extends AbstractALSServlet {
+
+  @Override
+  protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    OryxRecommender recommender = getRecommender();
+    try {
+      output(request, response, recommender.getAllUserIDs());
+    } catch (NotReadyException nre) {
+      response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE, nre.toString());
+    }
+  }
+}

--- a/als-serving/src/main/java/com/cloudera/oryx/als/serving/web/AllUserIDsServlet.java
+++ b/als-serving/src/main/java/com/cloudera/oryx/als/serving/web/AllUserIDsServlet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2013, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
 package com.cloudera.oryx.als.serving.web;
 
 import com.cloudera.oryx.als.common.NotReadyException;
@@ -9,7 +24,7 @@ import java.io.IOException;
 
 /**
  * <p>Responds to a GET request to {@code /user/allIDs}
- * and in turn calls {@link com.cloudera.oryx.als.common.OryxRecommender#getAllUserIDs()}.</p>
+ * and in turn calls {@link OryxRecommender#getAllUserIDs()}.</p>
  *
  * <p>CSV output is one user ID per line. JSON output is an array of user IDs.</p>
  *

--- a/als-serving/src/main/java/com/cloudera/oryx/als/serving/web/MostActiveUsersServlet.java
+++ b/als-serving/src/main/java/com/cloudera/oryx/als/serving/web/MostActiveUsersServlet.java
@@ -26,7 +26,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- * <p>Responds to a GET request to {@code /user/mostActiveIDs(?howMany=n)(&offset=o)}
+ * <p>Responds to a GET request to {@code /mostActiveUsers(?howMany=n)(&offset=o)}
  * and in turn calls {@link OryxRecommender#getMostActiveUsers(int)}.
  * {@code offset} is an offset into the entire list of results; {@code howMany} is the desired
  * number of results to return from there. For example, {@code offset=30} and {@code howMany=5}

--- a/als-serving/src/main/java/com/cloudera/oryx/als/serving/web/MostActiveUsersServlet.java
+++ b/als-serving/src/main/java/com/cloudera/oryx/als/serving/web/MostActiveUsersServlet.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2013, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.cloudera.oryx.als.serving.web;
+
+import com.cloudera.oryx.als.common.NotReadyException;
+import com.cloudera.oryx.als.common.OryxRecommender;
+import com.cloudera.oryx.als.common.rescorer.Rescorer;
+import com.cloudera.oryx.als.common.rescorer.RescorerProvider;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * <p>Responds to a GET request to {@code /user/mostActiveIDs(?howMany=n)(&offset=o)}
+ * and in turn calls {@link OryxRecommender#getMostActiveUsers(int)}.
+ * {@code offset} is an offset into the entire list of results; {@code howMany} is the desired
+ * number of results to return from there. For example, {@code offset=30} and {@code howMany=5}
+ * will cause the implementation to retrieve 35 results internally and output the last 5.
+ * If {@code howMany} is not specified, defaults to {@link AbstractALSServlet#DEFAULT_HOW_MANY}.
+ * {@code offset} defaults to 0.</p>
+ *
+ * <p>Output is as in {@link RecommendServlet}.</p>
+ * <p>CSV output contains one user per line, and each line is of the form {@code userID, strength},
+ * like {@code oryx, 2.0}. Strength is the number of items the user has interacted with.</p>
+ */
+public final class MostActiveUsersServlet extends AbstractALSServlet {
+
+  @Override
+  protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    OryxRecommender recommender = getRecommender();
+    try {
+      outputALSResult(request, response, recommender.getMostActiveUsers(getNumResultsToFetch(request)));
+    } catch (NotReadyException nre) {
+      response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE, nre.toString());
+    } catch (IllegalArgumentException iae) {
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, iae.toString());
+    }
+  }
+
+}

--- a/als-serving/src/main/jspx/test-als.jspx
+++ b/als-serving/src/main/jspx/test-als.jspx
@@ -125,6 +125,22 @@
     <tr><td colspan="4"><hr/></td></tr>
 
 <form action="#" style="padding:10px">
+  <tr><td><code>/user/allIDs</code></td>
+    <td colspan="2"/>
+    <td><a href="#" class="arrow" onclick="return doQuery('user/allIDs',true)">&amp;#x27AC;</a></td></tr>
+</form>
+
+    <tr><td colspan="4"><hr/></td></tr>
+
+<form action="#" style="padding:10px">
+  <tr><td><code>/user/mostActiveIDs</code></td>
+    <td colspan="2"/>
+    <td><a href="#" class="arrow" onclick="return doQuery('user/mostActiveIDs',true)">&amp;#x27AC;</a></td></tr>
+</form>
+
+  <tr><td colspan="4"><hr/></td></tr>
+
+<form action="#" style="padding:10px">
     <tr><td></td><td>&amp;nbsp;&amp;nbsp;User ID</td><td colspan="2"></td></tr>
     <tr><td><code>/knownItems</code></td>
         <td><code>/</code><input type="text" id="knownItems-userid" onkeyup="return handleReturn(event, 'knownItems',true,['userid'])"/></td>

--- a/als-serving/src/main/jspx/test-als.jspx
+++ b/als-serving/src/main/jspx/test-als.jspx
@@ -109,6 +109,14 @@
   <tr><td colspan="4"><hr/></td></tr>
 
 <form action="#" style="padding:10px">
+  <tr><td><code>/mostActiveUsers</code></td>
+    <td colspan="2"/>
+    <td><a href="#" class="arrow" onclick="return doQuery('mostActiveUsers',true)">&amp;#x27AC;</a></td></tr>
+</form>
+
+  <tr><td colspan="4"><hr/></td></tr>
+
+<form action="#" style="padding:10px">
   <tr><td><code>/popularRepresentativeItems</code></td>
     <td colspan="2"/>
     <td><a href="#" class="arrow" onclick="return doQuery('popularRepresentativeItems',true)">&amp;#x27AC;</a></td></tr>
@@ -131,14 +139,6 @@
 </form>
 
     <tr><td colspan="4"><hr/></td></tr>
-
-<form action="#" style="padding:10px">
-  <tr><td><code>/user/mostActiveIDs</code></td>
-    <td colspan="2"/>
-    <td><a href="#" class="arrow" onclick="return doQuery('user/mostActiveIDs',true)">&amp;#x27AC;</a></td></tr>
-</form>
-
-  <tr><td colspan="4"><hr/></td></tr>
 
 <form action="#" style="padding:10px">
     <tr><td></td><td>&amp;nbsp;&amp;nbsp;User ID</td><td colspan="2"></td></tr>


### PR DESCRIPTION
Hi Sean,

These endpoints have been useful in building a webpage to visualize the recommendations.

`/user/allIDs` returns all user ids, this can be troublesome though if you have millions of users.
`/user/mostActiveIds` returns a list of users sorted by the number of interactions with items.